### PR TITLE
Core/Bnet: SRP6a fix

### DIFF
--- a/src/server/bnetserver/Server/Session.cpp
+++ b/src/server/bnetserver/Server/Session.cpp
@@ -720,7 +720,7 @@ bool Battlenet::Session::HandlePasswordModule(BitStream* dataStream, ServerPacke
     clientM1.SetBinary(dataStream->ReadBytes(32).get(), 32);
     clientChallenge.SetBinary(dataStream->ReadBytes(128).get(), 128);
 
-    if (A.IsZero())
+    if ((A % N).IsZero())
     {
         Authentication::LogonResponse* logonResponse = new Authentication::LogonResponse();
         logonResponse->SetAuthResult(AUTH_CORRUPTED_MODULE);


### PR DESCRIPTION
**Issues addressed**: Fixes the same auth exploit as in GRUNT

**Tests performed**:  none.