### PR TITLE
InterruptSpell sending m_currentSpells as nullptr to CancelGlobalCooldown

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3002,14 +3002,13 @@ void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed, bool wi
             if (GetTypeId() == TYPEID_PLAYER)
                 ToPlayer()->SendAutoRepeatCancel(this);
 
-        m_currentSpells[spellType] = nullptr;
-
         if (spell->getState() != SPELL_STATE_FINISHED)
             spell->cancel();
 
         if (GetTypeId() == TYPEID_UNIT && IsAIEnabled)
             ToCreature()->AI()->OnSpellCastInterrupt(spell->GetSpellInfo());
 
+        m_currentSpells[spellType] = nullptr;
         spell->SetReferencedFromCurrent(false);
     }
 }


### PR DESCRIPTION
m_currentSpells[spellType] is set to nullptr before calling the cancel function which calls the CancelGlobalCooldown function, this results in the m_currentSpells[spellType] to be received as nullptr and because of that enters the second if statement in CancelGlobalCooldown which checks if the spells are equal.

Since it's now a nullptr, it's obviously not equal to the current interrupted spell, enters the if statement and returns without cancelling the GCD.

```
void Spell::CancelGlobalCooldown()
{
    if (!m_spellInfo->StartRecoveryTime)
        return;

    // Cancel global cooldown when interrupting current cast

    if (m_caster->GetCurrentSpell(CURRENT_GENERIC_SPELL) != this)
        return;

    // Only players or controlled units have global cooldown
    if (m_caster->GetTypeId() != TYPEID_PLAYER && !m_caster->GetCharmInfo())
        return;

    m_caster->GetSpellHistory()->CancelGlobalCooldown(m_spellInfo);
}
```
